### PR TITLE
Fix Invalid Filenames: Remove Colons to Resolve ffmpeg Export Issues

### DIFF
--- a/sample_video.py
+++ b/sample_video.py
@@ -48,7 +48,7 @@ def main():
     # Save samples
     for i, sample in enumerate(samples):
         sample = samples[i].unsqueeze(0)
-        time_flag = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d-%H:%M:%S")
+        time_flag = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d-%H-%M-%S")
         save_path = f"{save_path}/{time_flag}_seed{outputs['seeds'][i]}_{outputs['prompts'][i][:100].replace('/','')}.mp4"
         save_videos_grid(sample, save_path, fps=24)
         logger.info(f'Sample save to: {save_path}')


### PR DESCRIPTION
fix: remove colons from output filenames to prevent ffmpeg export failure